### PR TITLE
fixed slow system filtering

### DIFF
--- a/Screens/PlanetaryData/PlanetaryDataMain.xaml
+++ b/Screens/PlanetaryData/PlanetaryDataMain.xaml
@@ -184,7 +184,9 @@
                 BorderBrush="Gray"
                 BorderThickness="1"
                 ItemsSource="{Binding DisplayedSolarSystems}"
-                ScrollViewer.CanContentScroll="False">
+                ScrollViewer.CanContentScroll="True"
+                VirtualizingPanel.ScrollUnit="Pixel"
+                VirtualizingStackPanel.VirtualizationMode="Recycling">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid Margin="0,0,1,0">


### PR DESCRIPTION
The solar system list appeared to be laggy when typing in the filter TextBox. This was actually due to the ListView rendering being slowed due to virtualization being disabled by setting `ScrollViewer.CanContentScroll="False"`.
This change retains the behavior that `ScrollViewer.CanContentScroll="False"` offers (pixel scrolling), but also enables virtualizing (for performance).